### PR TITLE
Implement validation for quantity by riding on existing validations

### DIFF
--- a/src/main/java/seedu/foodrem/logic/commands/itemcommands/DecrementCommand.java
+++ b/src/main/java/seedu/foodrem/logic/commands/itemcommands/DecrementCommand.java
@@ -52,7 +52,13 @@ public class DecrementCommand extends Command {
     private static Item createDecrementedItem(Item itemToDecrement, ItemQuantity quantity) {
         assert itemToDecrement != null;
 
-        ItemQuantity decrementedQuantity = itemToDecrement.getQuantity().decrementQuantity(quantity);
+        ItemQuantity decrementedQuantity;
+        try {
+            decrementedQuantity = ItemQuantity.performArithmeticOperation(
+                    itemToDecrement.getQuantity(), quantity, (x, y) -> x - y);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("(Final Quantity) " + e.getMessage());
+        }
 
         return new Item(itemToDecrement.getName(),
                 decrementedQuantity,

--- a/src/main/java/seedu/foodrem/logic/commands/itemcommands/IncrementCommand.java
+++ b/src/main/java/seedu/foodrem/logic/commands/itemcommands/IncrementCommand.java
@@ -21,10 +21,11 @@ import seedu.foodrem.model.item.ItemQuantity;
 public class IncrementCommand extends Command {
     public static final String COMMAND_WORD = "inc";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Increments the quantity of the ttem identified"
-            + "by the index number used in the displayed item list. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Increments the quantity of the item identified "
+            + "by the index number used in the displayed item list.\n"
             + "Parameters: INDEX (must be a positive integer) "
-            + "[" + PREFIX_ITEM_QUANTITY + "QUANTITY] "
+            + "[" + PREFIX_ITEM_QUANTITY + "QUANTITY]\n"
             + "Example: " + COMMAND_WORD + " 10 ";
 
     public static final String MESSAGE_EDIT_ITEM_SUCCESS = "Incremented Item: %1$s";
@@ -51,7 +52,13 @@ public class IncrementCommand extends Command {
     private static Item createIncrementedItem(Item itemToIncrement, ItemQuantity quantity) {
         assert itemToIncrement != null;
 
-        ItemQuantity incrementedQuantity = itemToIncrement.getQuantity().incrementQuantity(quantity);
+        ItemQuantity incrementedQuantity;
+        try {
+            incrementedQuantity = ItemQuantity.performArithmeticOperation(
+                    itemToIncrement.getQuantity(), quantity, Double::sum);
+        } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException("(Final Quantity) " + e.getMessage());
+        }
 
         return new Item(itemToIncrement.getName(),
                 incrementedQuantity,

--- a/src/main/java/seedu/foodrem/logic/parser/DecrementCommandParser.java
+++ b/src/main/java/seedu/foodrem/logic/parser/DecrementCommandParser.java
@@ -7,7 +7,6 @@ import static seedu.foodrem.logic.parser.ParserUtil.arePrefixesPresent;
 
 import seedu.foodrem.commons.core.index.Index;
 import seedu.foodrem.logic.commands.itemcommands.DecrementCommand;
-import seedu.foodrem.logic.commands.itemcommands.EditCommand;
 import seedu.foodrem.logic.parser.exceptions.ParseException;
 import seedu.foodrem.model.item.ItemQuantity;
 
@@ -29,12 +28,12 @@ public class DecrementCommandParser implements Parser<DecrementCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DecrementCommand.MESSAGE_USAGE), pe);
         }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_ITEM_QUANTITY)
                 || argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DecrementCommand.MESSAGE_USAGE));
         }
 
         ItemQuantity decrementQuantity = ParserUtil.parseQuantity(argMultimap.getPresentValue(PREFIX_ITEM_QUANTITY));

--- a/src/main/java/seedu/foodrem/logic/parser/IncrementCommandParser.java
+++ b/src/main/java/seedu/foodrem/logic/parser/IncrementCommandParser.java
@@ -6,7 +6,6 @@ import static seedu.foodrem.logic.parser.CliSyntax.PREFIX_ITEM_QUANTITY;
 import static seedu.foodrem.logic.parser.ParserUtil.arePrefixesPresent;
 
 import seedu.foodrem.commons.core.index.Index;
-import seedu.foodrem.logic.commands.itemcommands.EditCommand;
 import seedu.foodrem.logic.commands.itemcommands.IncrementCommand;
 import seedu.foodrem.logic.parser.exceptions.ParseException;
 import seedu.foodrem.model.item.ItemQuantity;
@@ -29,12 +28,12 @@ public class IncrementCommandParser implements Parser<IncrementCommand> {
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, IncrementCommand.MESSAGE_USAGE), pe);
         }
 
         if (!arePrefixesPresent(argMultimap, PREFIX_ITEM_QUANTITY)
                 || argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE));
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, IncrementCommand.MESSAGE_USAGE));
         }
 
         ItemQuantity incrementQuantity = ParserUtil.parseQuantity(argMultimap.getPresentValue(PREFIX_ITEM_QUANTITY));

--- a/src/main/java/seedu/foodrem/model/item/ItemQuantity.java
+++ b/src/main/java/seedu/foodrem/model/item/ItemQuantity.java
@@ -2,6 +2,8 @@ package seedu.foodrem.model.item;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.function.BiFunction;
+
 import seedu.foodrem.model.item.itemvalidator.ItemQuantityValidator;
 
 
@@ -29,38 +31,13 @@ public class ItemQuantity {
     }
 
     /**
-     * Overloaded constructor that returns an ItemQuantity from a specified item quantity (double).
+     * Returns an itemQuantity after performing an arithmetic operation on them.
      */
-    public ItemQuantity(double itemQuantityDouble) {
-        requireNonNull(itemQuantityDouble);
-        // TODO: Add validation
-        this.itemQuantity = itemQuantityDouble;
-    }
-
-    /**
-     * Factory method that increments the ItemQuantity by a specified amount and returns a new ItemQuantity object
-     * with the quantity incremented.
-     *
-     * @param increment ItemQuantity amount to increment by.
-     * @return New ItemQuantity with quantity incremented.
-     */
-    public ItemQuantity incrementQuantity(ItemQuantity increment) {
-        // TODO: Needs validation to ensure item can be incremented with a valid amount, and final result is not
-        //  beyond the boundaries provided.
-        return new ItemQuantity(increment.itemQuantity + itemQuantity);
-    }
-
-    /**
-     * Factory method that decrements the ItemQuantity by a specified amount and returns a new ItemQuantity object
-     * with the quantity decremented..
-     *
-     * @param increment ItemQuantity amount to decrement by.
-     * @return New ItemQuantity with quantity decremented..
-     */
-    public ItemQuantity decrementQuantity(ItemQuantity increment) {
-        // TODO: Needs validation to ensure item can be incremented with a valid amount, and final result is not
-        //  beyond the boundaries provided.
-        return new ItemQuantity(itemQuantity - increment.itemQuantity);
+    public static ItemQuantity performArithmeticOperation(ItemQuantity itemQuantity1,
+                                                          ItemQuantity itemQuantity2,
+                                                          BiFunction<Double, Double, Double> op) {
+        double newQuantity = op.apply(itemQuantity1.itemQuantity, itemQuantity2.itemQuantity);
+        return new ItemQuantity(String.valueOf(newQuantity));
     }
 
     /**


### PR DESCRIPTION
To follow open close principle, 

In future if we want a function to double quantity (or perform any arithmetic operation, 

we do not need to edit item quantity.

There were also some errors with the messages. 

I formatted it a bit.